### PR TITLE
improved 004, focus on approver role

### DIFF
--- a/EVES/drafts/EVES-004/eves-004.md
+++ b/EVES/drafts/EVES-004/eves-004.md
@@ -1,7 +1,7 @@
 ---
 eves-identifier: 004
 title: ENVITED-X Roles and Responsibilities of EVES Editors
-author: Carlo van Driesten (@jdsika)
+author: Carlo van Driesten (@jdsika); Daniel Liebert (@dansan566)
 discussions-to:
 status: Draft
 type: Process
@@ -12,85 +12,131 @@ replaces: None
 
 ## Abstract
 
-This specification outlines the roles and responsibilities of EVES Editors within the ENVITED Ecosystem Specifications (EVES) process.
-Editors are tasked with maintaining the quality, consistency, and transparency of the EVES process, ensuring smooth collaboration among contributors.
-By clearly defining their scope, this document supports an effective and sustainable approach to managing the EVES lifecycle while fostering a collaborative and innovative environment.
+This specification outlines the roles and responsibilities of EVES Editors and Approvers within the ENVITED Ecosystem Specifications (EVES) process.
+Editors are tasked with maintaining the quality, consistency, and transparency of the EVES process, while Approvers hold the final voting authority to move a proposal from Candidate to Final.
+By clearly defining their scopes, this document supports an effective and sustainable approach to managing the EVES lifecycle and fosters a collaborative, innovative environment.
 
 ## Motivation
 
-EVES Editors are central to upholding the integrity of the ENVITED Ecosystem Specifications by ensuring that proposals meet established standards and processes.
-As the EVES framework grows, it is essential to define the scope of the editors' responsibilities to maintain efficiency and attract skilled contributors to this role.
-This specification provides clarity on the editors' tasks, empowering the community to drive innovation while enabling editors to focus on their core responsibilities.
+Editors and Approvers are central to upholding the integrity of the ENVITED Ecosystem Specifications by ensuring proposals meet established standards and follow due process.
+This specification clarifies each role’s tasks, empowering contributors to drive innovation while enabling Editors and Approvers to focus on their core responsibilities.
+It further aligns with the formal EVES lifecycle set forth in [EVES-001](../EVES-001/eves-001.md), which introduced the **Approvers** role.
 
 ## Specification
 
+This specification distinguishes between two formal roles: **Editors** and **Approvers**. Both are key to sustaining a transparent and high-quality EVES development process.
+
 ### 1. Roles of EVES Editors
 
-#### 1.1 Custodians of the EVES Repository
+#### 1.1 Custodians of the EVES Repository (Editors)
 
-- Manage the EVES GitHub repository to ensure it is organized, accessible, and up-to-date.
+- Manage the EVES GitHub repository to keep it organized and accessible.  
+- Oversee structural updates, file organization, and archiving of older EVES.
 
-#### 1.2 Reviewers of Specifications
+#### 1.2 Reviewers of Specifications (Editors)
 
-- Ensure that submitted EVES adhere to the template, style guide, and community standards.
+- Ensure that submitted EVES adhere to the template, style guide, and community standards.  
 - Provide feedback to authors to improve clarity, technical accuracy, and consistency.
 
-#### 1.3 Facilitators of Community Discussions
+#### 1.3 Facilitators of Community Discussions (Editors)
 
 - Moderate discussions on GitHub including issues and pull requests.
 - Encourage constructive feedback and active participation from stakeholders.
 
-#### 1.4 Arbiters of Consensus
+#### 1.4 Arbiters of Consensus (Editors)
 
-- Confirm that community consensus has been reached before an EVES advances in its lifecycle.
-- Mediate disagreements while remaining neutral.
+- Confirm that community consensus has been reached before an EVES advances from Draft → Review → Candidate stages.  
+- Mediate disagreements while remaining neutral in the editorial role.
 
-#### 1.5 Standards Enforcers
+#### 1.5 Standards Enforcers (Editors)
 
-- Verify that proposals align with overarching governance and standards (e.g., Gaia-X, W3C, Tezos TZIPs).
+- Verify that proposals align with overarching governance and standards (e.g., Gaia-X, W3C, Tezos TZIPs).  
 - Ensure interoperability within the ENVITED ecosystem.
+
+#### 1.6 Approvers
+
+- **Subset of Editors**: Approvers are a smaller group within the Editor pool, recognized by [EVES-001](../EVES-001/eves-001.md) as having additional voting authority to move an EVES from the Candidate to the Final stage.  
+- **Final Decision Makers**: They review EVES that have reached Candidate status (which must include a working reference implementation) and vote on whether the EVES is ready to become Final.  
+- **Voting Quorum**: EVES-001 requires at least two Approvers to confirm a proposal’s readiness for Final. Without meeting this quorum, the EVES remains in Candidate until further evidence, review, or revision is provided.  
+- **Alignment with ENVITED Goals**: Approvers ensure each EVES is not only well-structured and implementable but also aligned with the strategic objectives of ENVITED-X and the broader ASCS e.V. membership.
 
 ### 2. Responsibilities of EVES Editors
 
+Editors maintain their established responsibilities while collaborating with the newly introduced Approvers. The following responsibilities apply to Editors throughout the EVES process, from Draft creation to Finalization or Rejection.
+
 #### 2.1 Pre-Submission
 
-- Assist authors in structuring and formatting their EVES drafts.
-- Provide guidance on effective proposal writing and submission processes.
+- Assist authors in structuring and formatting drafts according to the EVES template.  
+- Provide guidance on proposal writing and GitHub submission processes.
 
 #### 2.2 Submission and Review Process
 
-- **Initial Review**:
-  - Check for completeness and adherence to the EVES template.
-  - Ensure technical accuracy and clarity.
-- **Feedback Cycle**:
-  - Return drafts with constructive feedback and suggested revisions.
-- **Editorial Approval**:
-  - Approve EVES drafts for community review once they meet required standards.
+1. **Initial Review**  
+   - Check for completeness, adherence to the EVES template, and style guide compliance.  
+   - Ensure that the submission aligns with the broader ENVITED-X or Gaia-X governance requirements.  
+2. **Feedback Cycle**  
+   - Return drafts with constructive feedback, suggested revisions, and further reading.  
+   - Resolve conflicting or duplicate proposals in coordination with the community.  
+3. **Editorial Approval**  
+   - Editors grant the green light for an EVES to move into **Review** or **Candidate** status, contingent on meeting the exit criteria in [EVES-001](../EVES-001/eves-001.md).
 
 #### 2.3 Community Engagement
 
-- Organize public reviews and feedback sessions.
-- Ensure diverse perspectives are considered during discussions.
+- Organize and announce public reviews, calls, and feedback sessions.  
+- Guarantee that diverse perspectives are included, including technical experts, domain specialists, and members of the ASCS e.V.
 
-#### 2.4 Advancement of EVES
+#### 2.4 Advancement Through the EVES Lifecycle
 
-- Guide EVES through its lifecycle stages:
-  - **Draft** → **Review** → **Candidate** → **Final**
-- Ensure all advancement criteria are met, including the inclusion of reference implementations.
+- Guide EVES through the Draft → Review → Candidate stages, ensuring the exit criteria are satisfied at each step.  
+- Work closely with Approvers to confirm readiness for Final. Although Editors facilitate the process, the final decision is subject to Approvers’ votes.
 
 #### 2.5 Governance and Accountability
 
-- Uphold openness, inclusivity, and neutrality in all interactions.
-- Comply with the governance rules of the ENVITED Research Cluster, as outlined [here](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
+- Uphold openness, inclusivity, and neutrality in editorial interactions.  
+- Comply with the governance rules of the ENVITED Research Cluster and follow the conflict resolution mechanisms set forth in [EVES-001](../EVES-001/eves-001.md) and the [OpenMSL Governance Rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
 
-### 3. Becoming an EVES Editor
+### 3. Responsibilities of Approvers
+
+Approvers operate on top of the Editors’ responsibilities, taking an active role primarily when an EVES has entered the Candidate stage.
+
+#### 3.1 Gatekeeping Candidate to Final
+
+- Verify that the EVES has demonstrated feasibility via a working reference implementation.  
+- Review any major technical or legal constraints to confirm the EVES can serve as an official standard or process reference.
+
+#### 3.2 Voting Procedure
+
+- **Quorum**: A minimum of two Approvers must confirm to move a Candidate EVES to Final.  
+- **Neutrality and Fairness**: Approvers should weigh all community feedback, Editor recommendations, and test results from reference implementations before voting.
+
+#### 3.3 Final Publication
+
+- Once a successful vote is concluded, Approvers may instruct Editors to merge or publish the EVES as **Final**.  
+- Oversee any minor editorial clarifications that may be integrated after Final approval.
+
+### 4. Becoming an EVES Editor or Approver
+
+#### 4.1 Application Process (Editors)
+
+- Anyone interested in becoming an EVES Editor can open a discussion or issue in the ENVITED GitHub organization.  
+- New editors are evaluated on their familiarity with the EVES process and willingness to adhere to editorial standards.
+
+#### 4.2 Elevation to Approver
+
+- Approvers are drawn from the existing Editor pool, typically based on demonstrated expertise and active involvement with EVES proposals.  
+- Final confirmation may require a majority vote of existing Approvers or the ASCS e.V. ENVITED TSC, in keeping with local governance rules.
+
+#### 4.3 Meetings
+
+- Editors and Approvers hold open calls regularly. Links to these calls are pinned in the GitHub organization.  
+- Meeting notes are stored in the `protocols/` folder within the EVES repository for public reference.
 
 1. **Application Process**:
    - Anyone interested in becoming an EVES Editor can open a discussion in the ENVITED GitHub organization.
    - Tag the current editors group (e.g., `@eves-editors`) in the discussion for visibility.
 
 2. **Eligibility**:
-   - Applicants MUST demonstrate familiarity with the EVES process, template, and standards as defined in [EVES-001](https://github.com/ASCS-eV/EVES/blob/main/drafts/EVES-001/EVES-001.md) and this document.
+   - Applicants MUST demonstrate familiarity with the EVES process, template, and standards as defined in [EVES-001](../EVES-001/eves-001.md)) and this document.
    - New editors are welcome, and all qualified contributors can join to support the collaborative effort.
 
 3. **Approval**:
@@ -100,67 +146,39 @@ This specification provides clarity on the editors' tasks, empowering the commun
    - Editors meet regularly in open calls. Links to these calls are pinned in the GitHub organization.
    - Meeting protocols are stored in the `protocols/` folder within the EVES repository for transparency and accountability.
 
-### 4. What EVES Editors Are Not Responsible For
+### 5. What EVES Editors and Approvers Are Not Responsible For
 
-#### 4.1 Driving the Creation of New EVES
+The following points clarify limits to the Editor and Approver roles:
 
-- Editors do not initiate or drive the development of new EVES.  
-- The community is responsible for identifying needs and drafting proposals.
+1. **Creation of New EVES**  
+   - Neither Editors nor Approvers drive the creation of new EVES; the community identifies needs, and authors propose solutions.  
+2. **Technical Designs or Implementations**  
+   - They do not craft or own the underlying technical designs (e.g., code libraries). The community or EVES authors lead the design, while Editors and Approvers review it for feasibility.  
+3. **Promotion or Adoption**  
+   - They are not tasked with marketing or ensuring the adoption of specific EVES. Deployment and integration lie with the community and stakeholders.  
+4. **Post-Final Maintenance**  
+   - Once an EVES is Final, it falls to the original authors or relevant contributors to maintain or propose updates. Major changes require a new EVES, as stated in [EVES-001](../EVES-001/eves-001.md).
 
-#### 4.2 Providing Technical Designs or Implementations
+### 6. Modular Governance Model
 
-- Authors and contributors are solely responsible for technical designs and reference implementations.
-- Information about e.g designs and technical implementations are only exchanged for the purpose of defining the specification.
+1. **Editors ensure process adherence**: They provide editorial consistency, confirm that proposals meet formal requirements, and moderate community input.  
+2. **Approvers validate final readiness**: By voting on the Candidate → Final transition, Approvers function as a final gate to ensure quality and strategic alignment.  
+3. **Community drives innovation**: Ideas originate from community members; they refine proposals, handle technical details, and implement reference solutions.
 
-#### 4.3 Advocating for Specific Proposals
-
-- Editors remain neutral and do not advocate for or against specific EVES during the review process.
-
-#### 4.4 Resolving Technical Disputes
-
-- Editors facilitate discussions but do not resolve technical disagreements.  
-- The community or an ASCS governance body decides on such matters.
-
-#### 4.5 Ensuring High-Quality Proposals
-
-- Editors review submissions for compliance but are not solely responsible for their quality.  
-- Authors and contributors must provide technically sound and complete proposals.
-
-#### 4.6 Promoting or Ensuring Adoption of EVES
-
-- Editors are not tasked with promoting specific EVES or ensuring their adoption.
-- The adoption of EVES is the free choice of every community member.
-- Community members and stakeholders are solely responsible to drive the promotion and integration of Final EVES.
-
-#### 4.7 Maintaining Approved EVES
-
-- Once an EVES reaches Final status, its maintenance becomes the responsibility of the original authors or interested contributors.
-
-## Modular Governance Model
-
-This specification emphasizes a modular governance model where:
-
-1. **Editors ensure process adherence** but are not burdened with community responsibilities.
-2. **The community drives innovation** by identifying needs, drafting EVES, and proposing updates.
-3. **Governance bodies oversee alignment** with the strategic goals of ENVITED-X.
-
-## Key Resources for Editors
-
-- **GitHub Repository**:
-  - Maintain and moderate the EVES repository at [https://github.com/ASCS-eV/EVES](https://github.com/ASCS-eV/EVES).
-- **Templates and Style Guides**:
-  - Use and update resources in the `resources/` folder to ensure consistency.
-- **Community Platforms**:
-  - Engage stakeholders via GitHub issues, pull requests, and forums.
-- **Governance Rules**:
-  - Follow the governance rules outlined [here](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
+This modular governance ensures each role maintains focused responsibilities, thereby optimizing editorial efficiency and encouraging community-driven innovation.
 
 ## Backwards Compatibility
 
-This EVES introduces no breaking changes and is complementary to the existing EVES process defined in [EVES-001](https://github.com/ASCS-eV/EVES/blob/main/drafts/EVES-001/EVES-001.md).
+This EVES clarifies and expands the editorial process defined in EVE[S-001](../EVES-001/eves-001.md) by adding the Approvers role. It does not invalidate any previous guidelines and remains fully compatible with existing EVES. No retroactive changes are required; any references to “Editors” in older documents may be read inclusively to account for the separate Approvers subset going forward.
 
 ## References
 
-1. [EVES-001: EVES Process Definition](https://github.com/ASCS-eV/EVES/blob/main/drafts/EVES-001/EVES-001.md)
-2. [OpenMSL Governance Rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html)
-3. [EIP-1: Ethereum Improvement Proposal Process](https://eips.ethereum.org/EIPS/eip-1)
+1. [EVES-001: EVES Process Definition](../EVES-001/eves-001.md)  
+2. [OpenMSL Governance Rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html)  
+3. [EIP-1: Ethereum Improvement Proposal Process](https://eips.ethereum.org/EIPS/eip-1) (Inspiration for open standards processes)
+
+---
+
+## Implementation
+
+No direct implementation is required for this EVES. However, existing Editors and Approvers are encouraged to adopt these clarifications immediately for all in-flight and future EVES proposals.

--- a/EVES/drafts/EVES-004/eves-004.md
+++ b/EVES/drafts/EVES-004/eves-004.md
@@ -183,4 +183,6 @@ No retroactive changes are required; any references to “Editors” in older do
 
 ## Implementation
 
-No direct implementation is required for this EVES. However, existing Editors and Approvers are encouraged to adopt these clarifications immediately for all in-flight and future EVES proposals. The Github Team [EVES Editors](https://github.com/orgs/ASCS-eV/teams/eves-editors) and [EVES Approvers](https://github.com/orgs/ASCS-eV/teams/eves-approvers) are created in the ASCS gitHub organization.
+No direct implementation is required for this EVES.
+However, existing Editors and Approvers are encouraged to adopt these clarifications immediately for all in-flight and future EVES proposals.
+The Github Team [EVES Editors](https://github.com/orgs/ASCS-eV/teams/eves-editors) and [EVES Approvers](https://github.com/orgs/ASCS-eV/teams/eves-approvers) are created in the ASCS gitHub organization.

--- a/EVES/drafts/EVES-004/eves-004.md
+++ b/EVES/drafts/EVES-004/eves-004.md
@@ -169,7 +169,9 @@ This modular governance ensures each role maintains focused responsibilities, th
 
 ## Backwards Compatibility
 
-This EVES clarifies and expands the editorial process defined in EVE[S-001](../EVES-001/eves-001.md) by adding the Approvers role. It does not invalidate any previous guidelines and remains fully compatible with existing EVES. No retroactive changes are required; any references to “Editors” in older documents may be read inclusively to account for the separate Approvers subset going forward.
+This EVES clarifies and expands the editorial process defined in EVE[S-001](../EVES-001/eves-001.md) by adding the Approvers role.
+It does not invalidate any previous guidelines and remains fully compatible with existing EVES.
+No retroactive changes are required; any references to “Editors” in older documents may be read inclusively to account for the separate Approvers subset going forward.
 
 ## References
 

--- a/EVES/drafts/EVES-004/eves-004.md
+++ b/EVES/drafts/EVES-004/eves-004.md
@@ -3,7 +3,7 @@ eves-identifier: 004
 title: ENVITED-X Roles and Responsibilities of EVES Editors
 author: Carlo van Driesten (@jdsika); Daniel Liebert (@dansan566)
 discussions-to:
-status: Draft
+status: Review
 type: Process
 created: 2024-11-24
 requires: ["EVES-001"]
@@ -62,7 +62,8 @@ This specification distinguishes between two formal roles: **Editors** and **App
 
 ### 2. Responsibilities of EVES Editors
 
-Editors maintain their established responsibilities while collaborating with the newly introduced Approvers. The following responsibilities apply to Editors throughout the EVES process, from Draft creation to Finalization or Rejection.
+Editors maintain their established responsibilities while collaborating with the newly introduced Approvers.
+The following responsibilities apply to Editors throughout the EVES process, from Draft creation to Finalization or Rejection.
 
 #### 2.1 Pre-Submission
 
@@ -88,7 +89,8 @@ Editors maintain their established responsibilities while collaborating with the
 #### 2.4 Advancement Through the EVES Lifecycle
 
 - Guide EVES through the Draft → Review → Candidate stages, ensuring the exit criteria are satisfied at each step.  
-- Work closely with Approvers to confirm readiness for Final. Although Editors facilitate the process, the final decision is subject to Approvers’ votes.
+- Work closely with Approvers to confirm readiness for Final.
+  Although Editors facilitate the process, the final decision is subject to Approvers’ votes.
 
 #### 2.5 Governance and Accountability
 
@@ -153,11 +155,14 @@ The following points clarify limits to the Editor and Approver roles:
 1. **Creation of New EVES**  
    - Neither Editors nor Approvers drive the creation of new EVES; the community identifies needs, and authors propose solutions.  
 2. **Technical Designs or Implementations**  
-   - They do not craft or own the underlying technical designs (e.g., code libraries). The community or EVES authors lead the design, while Editors and Approvers review it for feasibility.  
+   - They do not craft or own the underlying technical designs (e.g., code libraries).
+     The community or EVES authors lead the design, while Editors and Approvers review it for feasibility.  
 3. **Promotion or Adoption**  
-   - They are not tasked with marketing or ensuring the adoption of specific EVES. Deployment and integration lie with the community and stakeholders.  
+   - They are not tasked with marketing or ensuring the adoption of specific EVES.
+     Deployment and integration lie with the community and stakeholders.  
 4. **Post-Final Maintenance**  
-   - Once an EVES is Final, it falls to the original authors or relevant contributors to maintain or propose updates. Major changes require a new EVES, as stated in [EVES-001](../EVES-001/eves-001.md).
+   - Once an EVES is Final, it falls to the original authors or relevant contributors to maintain or propose updates.
+     Major changes require a new EVES, as stated in [EVES-001](../EVES-001/eves-001.md).
 
 ### 6. Modular Governance Model
 
@@ -178,8 +183,6 @@ No retroactive changes are required; any references to “Editors” in older do
 1. [EVES-001: EVES Process Definition](../EVES-001/eves-001.md)  
 2. [OpenMSL Governance Rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html)  
 3. [EIP-1: Ethereum Improvement Proposal Process](https://eips.ethereum.org/EIPS/eip-1) (Inspiration for open standards processes)
-
----
 
 ## Implementation
 

--- a/EVES/drafts/EVES-004/eves-004.md
+++ b/EVES/drafts/EVES-004/eves-004.md
@@ -136,7 +136,7 @@ Approvers operate on top of the Editors’ responsibilities, taking an active ro
    - Tag the current editors group (e.g., `@eves-editors`) in the discussion for visibility.
 
 2. **Eligibility**:
-   - Applicants MUST demonstrate familiarity with the EVES process, template, and standards as defined in [EVES-001](../EVES-001/eves-001.md)) and this document.
+   - Applicants MUST demonstrate familiarity with the EVES process, template, and standards as defined in [EVES-001](../EVES-001/eves-001.md) and this document.
    - New editors are welcome, and all qualified contributors can join to support the collaborative effort.
 
 3. **Approval**:
@@ -169,7 +169,7 @@ This modular governance ensures each role maintains focused responsibilities, th
 
 ## Backwards Compatibility
 
-This EVES clarifies and expands the editorial process defined in EVE[S-001](../EVES-001/eves-001.md) by adding the Approvers role.
+This EVES clarifies and expands the editorial process defined in [EVES-001](../EVES-001/eves-001.md) by adding the Approvers role.
 It does not invalidate any previous guidelines and remains fully compatible with existing EVES.
 No retroactive changes are required; any references to “Editors” in older documents may be read inclusively to account for the separate Approvers subset going forward.
 
@@ -183,4 +183,4 @@ No retroactive changes are required; any references to “Editors” in older do
 
 ## Implementation
 
-No direct implementation is required for this EVES. However, existing Editors and Approvers are encouraged to adopt these clarifications immediately for all in-flight and future EVES proposals.
+No direct implementation is required for this EVES. However, existing Editors and Approvers are encouraged to adopt these clarifications immediately for all in-flight and future EVES proposals. The Github Team [EVES Editors](https://github.com/orgs/ASCS-eV/teams/eves-editors) and [EVES Approvers](https://github.com/orgs/ASCS-eV/teams/eves-approvers) are created in the ASCS gitHub organization.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The process on how to write, submit or change specifications in defined in [EVES
 
 | Number | Title | Type | Status |
 | ------ | ----- | ---- | ------ |
-| [001](./EVES/drafts/EVES-001/eves-001.md) | ENVITED-X Ecosystem Specification Process            | Process   | Draft |
-| [002](./EVES/drafts/EVES-002/eves-002.md) | ENVITED-X Data Space Architecture Overview           | Standards | Draft |
-| [003](./EVES/drafts/EVES-003/eves-003.md) | ENVITED-X Asset Definition and Upload Process        | Standards | Draft |
-| [004](./EVES/drafts/EVES-004/eves-004.md) | ENVITED-X Roles and Responsibilities of EVES Editors | Process   | Draft |
-| [005](./EVES/drafts/EVES-005/eves-005.md) | ENVITED-X Contract Negotiation Process               | Process   | Draft |
-| [006](./EVES/drafts/EVES-006/eves-006.md) | ENVITED-X Scaling Architecture                       | Process   | Draft |
+| [001](./EVES/drafts/EVES-001/eves-001.md) | ENVITED-X Ecosystem Specification Process            | Process   | Draft  |
+| [002](./EVES/drafts/EVES-002/eves-002.md) | ENVITED-X Data Space Architecture Overview           | Standards | Draft  |
+| [003](./EVES/drafts/EVES-003/eves-003.md) | ENVITED-X Asset Definition and Upload Process        | Standards | Draft  |
+| [004](./EVES/drafts/EVES-004/eves-004.md) | ENVITED-X Roles and Responsibilities of EVES Editors | Process   | Review |
+| [005](./EVES/drafts/EVES-005/eves-005.md) | ENVITED-X Contract Negotiation Process               | Process   | Draft  |
+| [006](./EVES/drafts/EVES-006/eves-006.md) | ENVITED-X Scaling Architecture                       | Process   | Draft  |


### PR DESCRIPTION
## Summary of Changes

This PR revises **EVES-004** to include a new role, **Approvers**, and to ensure alignment with the latest **EVES-001** requirements. The key modifications are:

1. **Integration of Approvers Role:**
   - Defines a smaller subset of Editors, called **Approvers**, with the authority to finalize EVES proposals at the Candidate stage.
   - Clarifies their voting quorum and decision-making process (requiring at least two Approvers to grant **Final** status).

2. **References to EVES-001:**
   - Directly cites [EVES-001](../EVES-001/eves-001.md) in multiple places, ensuring consistency with the established EVES lifecycle and governance structure.

3. **Expanded Responsibilities Section:**
   - Outlines which tasks are specifically handled by Editors vs. Approvers.
   - Explains how Editors facilitate community engagement, while Approvers vote on EVES finalization.

4. **Reworked Governance Model:**
   - Emphasizes a modular approach: Editors oversee editorial quality and compliance, while Approvers confirm final readiness.

5. **Backward Compatibility:**
   - Maintains compatibility with existing processes, stating that no retroactive changes are needed for older EVES.

## Why These Changes Are Needed

- **Role Clarification:** Previous versions of EVES-004 did not specify how the new Approvers role fits within the existing Editor duties.
- **Lifecycle Alignment:** Ensures this process document fully reflects EVES-001’s lifecycle (Draft → Review → Candidate → Final) and clarifies how final approval is obtained.
- **Efficient Governance:** Assigning clear responsibilities for both Editors and Approvers helps streamline and formalize the EVES acceptance flow.

## How It Works

- **Editors** remain custodians of the repository and lead the editorial review process for new and existing EVES documents.
- **Approvers** form a specialized subset of Editors, granting final approval based on quorum rules set by EVES-001.

## Impact

- No breaking changes are introduced for existing EVES.
- Current Editors can continue their responsibilities, and community members can better understand the final approval step.
- Offers a clear path to onboard new Editors or elevate existing ones to Approver status.

## Next Steps

- Merge the updated EVES-004 into the main branch once approvals are given.
- Encourage contributors to reference these clarified roles whenever proposing or reviewing new EVES.