### PR TITLE
fix(ci): resolve CI failures, add Vale to pre-commit, fix broken links

### DIFF
--- a/.github/styles/Vocab/EVES/accept.txt
+++ b/.github/styles/Vocab/EVES/accept.txt
@@ -29,3 +29,4 @@ DPoP
 SPARQL
 SSI
 Catena-X
+e\.V\.

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore lychee cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: .lycheecache
           key: lychee-cache-${{ github.sha }}
           restore-keys: lychee-cache-
 
       - name: Check links
-        uses: lycheeverse/lychee-action@f81112d0d2814ded911bd23e3beaa9dda9f8ca55 # v2.3.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --cache

--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@db4f21d957a58a0515c3e6b0fb16b2a13e97a1e6 # v19.1.0
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
         with:
           config: .markdownlint.json
           globs: "**/*.md"

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,13 @@
+# Forward references to EVES specs not yet written
+EVES-009/eves-009.md
+
+# Placeholder/example URLs used in spec text (not real endpoints)
+https://assets.envited-x.net/
+https://metadata.envited-x.net/
+https://ipfs.envited-x.net/
+
+# GitLab blocks automated requests with 403
+https://gitlab.com/tezos/tzip/
+
+# Flaky external sites (intermittent connection resets in CI)
+https://www.conventionalcommits.org/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,16 @@ repos:
       - id: markdownlint
         args: ["--config", ".markdownlint.json"]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: npx prettier --check --ignore-path .prettierignore
+        language: system
         types_or: [markdown, json, yaml]
-        args: ["--prose-wrap", "preserve"]
+
+  - repo: https://github.com/errata-ai/vale
+    rev: v3.9.6
+    hooks:
+      - id: vale
+        types: [markdown]

--- a/.vale.ini
+++ b/.vale.ini
@@ -10,3 +10,30 @@ BasedOnStyles = Vale, Google, proselint, write-good
 Google.Acronyms = NO
 Google.We = NO
 Vale.Spelling = NO
+# EVES specs quote field names like "name", "tags" — comma placement doesn't apply
+Google.Quotes = NO
+# NOTE/TODO in blockquotes is standard RFC/spec style
+proselint.Annotations = NO
+# EVES uses spaced em-dashes (` — `) consistently
+Google.EmDash = NO
+# Filenames contain "..." which is not prose typography
+proselint.Typography = NO
+# "e.V." is the German legal abbreviation (eingetragener Verein)
+Google.Spacing = NO
+# Occasional emphasis is acceptable in specs
+Google.Exclamation = NO
+# Passive voice is standard in normative specifications ("MUST be derived from...")
+write-good.Passive = NO
+Google.Passive = NO
+# E-Prime ("avoid is/are/was") is incompatible with specification language
+write-good.E-Prime = NO
+# "however", "indicate", "requirement" are normal technical terms
+write-good.TooWordy = NO
+# Specs use title-case section headings (e.g. "Backwards Compatibility")
+Google.Headings = NO
+# Specs MUST NOT use contractions per formal writing conventions
+Google.Contractions = NO
+# Parenthetical clarifications are common in specs
+Google.Parens = NO
+# Semicolons are appropriate in complex specification sentences
+Google.Semicolons = NO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+## Project overview
+
+EVES (ENVITED-X Verifiable Ecosystem Specifications) defines standards for the ENVITED-X Data Space.
+Each specification lives in `EVES/EVES-NNN/eves-nnn.md` with associated examples, schemas, and assets.
+
+## Setup
+
+```sh
+npm install
+pre-commit install
+```
+
+## Quality checks
+
+Before every commit, run:
+
+```sh
+make lint          # markdownlint + frontmatter validation
+make format-check  # Prettier formatting
+```
+
+Pre-commit hooks enforce: trailing whitespace, end-of-file newlines, valid YAML/JSON, no merge conflicts, markdownlint, Prettier formatting (check mode), and Vale prose linting.
+
+If Prettier fails, run `npx prettier --write .` to auto-format, then re-stage and commit.
+
+CI additionally runs link checking (`link_checker.yml`).
+
+### Vale prose lint rules
+
+The project uses Vale with Google, proselint, and write-good styles (see `.vale.ini`).
+Several rules are disabled because they conflict with technical specification conventions (see comments in `.vale.ini`).
+
+Key active rule that causes CI failures:
+
+- Use "for example" instead of "e.g." or "i.e." (`Google.Latin`)
+
+To run Vale locally: install [Vale](https://vale.sh/docs/install), then `vale sync && vale EVES/`.
+
+### Markdown lint rules
+
+See `.markdownlint.json`. Maximum line length is 300 characters (tables and code blocks are exempt).
+HTML elements `<a>`, `<br>`, `<img>`, `<sup>` are allowed.
+
+## File conventions
+
+- Specification documents use YAML frontmatter with fields: `eves-identifier`, `title`, `author`, `status`, `type`, `created`, `requires`, `replaces`
+- JSON schemas go in `eves-nnn-schemas/` directories (excluded from Prettier in `.prettierignore`)
+- Example files go in `example/` directories (excluded from Prettier in `.prettierignore`)
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) with scope: `feat(EVES-003): ...`, `fix(ci): ...`
+- Branches follow `feat/eves-nnn-description` naming
+
+## Ontology references
+
+The ENVITED-X ontologies are maintained in [ontology-management-base](https://github.com/ASCS-eV/ontology-management-base).
+Current versions: `envited-x/v3/`, `manifest/v5/`, `hdmap/v6/`.
+
+The Gaia-X ontology follows the Loire (25.11) release. Key naming:
+
+- `envited-x:ResourceDescription` (subclass of `gx:VirtualResource`) carries the GX compliance metadata
+- `gx:name`, `gx:description` are used in the `envited-x:ResourceDescriptionShape` SHACL
+- `gx:license`, `gx:copyrightOwnedBy`, `gx:resourcePolicy` remain GX-native properties

--- a/EVES/EVES-001/eves-001.md
+++ b/EVES/EVES-001/eves-001.md
@@ -64,7 +64,7 @@ Each EVES must pass through the following stages:
    - **Future Changes**: Only changes designated as a minor editorial update by Editors are allowed in this stage.
 
 5. **Deferred/Rejected**
-   - **Deferred**: The EVES is paused for future discussion (e.g., lack of resources, overshadowed by another proposal).
+   - **Deferred**: The EVES is paused for future discussion (for example, lack of resources, overshadowed by another proposal).
    - **Rejected**: Consensus cannot be reached, or the specification is fundamentally misaligned with ENVITED-X goals.
 
 6. **Superseded**
@@ -85,20 +85,20 @@ Each EVES must pass through the following stages:
 ### 2. EVES Numbering
 
 - EVES documents follow sequential numbering, starting from EVES-001, EVES-002, and so on.
-- Numbers must be unique and stable once assigned (i.e., no recycling of identifiers).
+- Numbers must be unique and stable once assigned (that is, no recycling of identifiers).
 
 ### 3. EVES Types
 
 Each EVES must declare one of the following **type** fields in its YAML header:
 
 1. **Standards**
-   - Defines technical specifications or protocols recommended for ecosystem adoption (e.g., data formats, APIs).
+   - Defines technical specifications or protocols recommended for ecosystem adoption (for example, data formats, APIs).
 
 2. **Informational**
    - Provides context, best practices, or reference material without strict normative requirements.
 
 3. **Process**
-   - Outlines procedural or governance rules applicable to the ENVITED community (e.g., this EVES-001).
+   - Outlines procedural or governance rules applicable to the ENVITED community (for example, this EVES-001).
 
 ### 4. Roles and Responsibilities
 
@@ -121,7 +121,7 @@ Each EVES must declare one of the following **type** fields in its YAML header:
 
 - A subset of EVES Editors with voting rights as full ASCS e.V. ENVITED members.
 - Provide the final decision on moving an EVES from Candidate to Final.
-- Must meet quorum requirements (e.g., at least two Approvers) to grant or deny Final status.
+- Must meet quorum requirements (for example, at least two Approvers) to grant or deny Final status.
 
 ### 4.5 Conflict Resolution
 

--- a/EVES/EVES-002/eves-002.md
+++ b/EVES/EVES-002/eves-002.md
@@ -36,10 +36,10 @@ The ENVITED-X Data Space is built on the following core modules:
 
 - **Purpose**:
   - Establish trust by verifying user and organization identities.
-  - Enable permission management (e.g., membership validation, terms of service acceptance).
+  - Enable permission management (for example, membership validation, terms of service acceptance).
 - **Key Features**:
   - Credentials are issued via [SimpulseID](https://identity.ascs.digital) and stored in W3C-compliant wallets like [Altme](https://altme.io).
-  - Future support for contract-based credentials (e.g., purchase or download permissions).
+  - Future support for contract-based credentials (for example, purchase or download permissions).
 - **Standards**:
   - Gaia-X Trust Framework.
   - W3C Verifiable Credentials and DIDs.
@@ -52,7 +52,7 @@ The ENVITED-X Data Space is built on the following core modules:
   - Enable real-time credential checks during system interactions.
 - **Functionality**:
   - Tracks the **uuid** of credentials to ensure privacy.
-  - Manages credential statuses (e.g., active/inactive for revocation).
+  - Manages credential statuses (for example, active/inactive for revocation).
 - **Use Cases**:
   - Credential validation during login.
   - Whitelisting users for minting and accessing assets.
@@ -99,11 +99,11 @@ The interaction between modules can be summarized as follows:
 1. **Credential Issuance**:
    - A user or organization requests a credential via SimpulseID following the process in EVES-008.
    - Credential metadata includes identity, permissions, and additional attributes.
-   - Credential is stored in a wallet (e.g., Altme) and referenced by uuid in the registry contract.
+   - Credential is stored in a wallet (for example, Altme) and referenced by uuid in the registry contract.
 
 2. **Login and Validation**:
    - User logs in to ENVITED-X.
-   - The system validates the credential (e.g., membership status) via the registry contract.
+   - The system validates the credential (for example, membership status) via the registry contract.
 
 3. **Asset Registration**:
    - User uploads simulation assets to ENVITED-X following the process in EVES-003.
@@ -142,7 +142,7 @@ Future EVES will provide detailed specifications for each module.
 
 1. [SimpulseID](https://identity.ascs.digital)
 2. [Altme Wallet](https://altme.io)
-3. [Tezos FA2.1 Standard](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-21/tzip-21.md)
+3. [Tezos FA2.1 Standard](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-21/tzip-21.md)
 4. [Etherlink Bridge](https://www.etherlinkbridge.com/bridge)
 5. [EVES-003: ENVITED Asset Definition and Upload Process](../EVES-003/eves-003.md)
 6. [Gaia-X Trust Framework](https://docs.gaia-x.eu/policy-rules-committee/compliance-document/24.11/)

--- a/EVES/EVES-003/eves-003.md
+++ b/EVES/EVES-003/eves-003.md
@@ -31,7 +31,7 @@ This EVES addresses the need for clear guidelines to onboard assets and synchron
 
 The `envited-x:SimulationAsset` defines a digital asset within the domain of simulation including the core simulation data and all necessary files for describing, evaluating, and visualizing the dataset.
 All simulation assets MUST be derived from a common `envited-x` ontology defined in the [Gaia-X 4 PLC-AAD Ontology Management Base][1].
-A data space portal SHALL display the currently supported version of the ontologies like e.g.: `https://ontologies.envited-x.net/envited-x/v2/ontology#`.
+A data space portal SHALL display the currently supported version of the ontologies such as: `https://ontologies.envited-x.net/envited-x/v2/ontology#`.
 Each simulation asset SHALL be compliant with the [Gaia-X Ontology and SHACL shapes 2210][2].
 The `gx` turtle shacle shapes are derived from the [Gaia-X Trust Framework Schema][3] and the respective application/ld+json [Gaia-X Trust Framework Shapes][4].
 A [GaiaX Compliant Claims Example][5] MAY be generated using the [GaiaX 4 PLC-AAD Claim Compliance Provider][6].
@@ -54,15 +54,15 @@ Tooling such as the [ENVITED-X Simulation Asset Tools][20] MAY automate the crea
 
 Every `asset.zip` MUST contain the following top-level folders mapped to `envited-x` artifact categories:
 
-| Folder                | `envited-x` Category           | Required    | `envited-x` Access Role | Description                                     |
-| --------------------- | ------------------------------ | ----------- | ----------------------- | ----------------------------------------------- |
-| `simulation-data/`    | `envited-x:isSimulationData`   | MUST        | `envited-x:isOwner`     | Core simulation data (e.g., `.xodr`, `.xosc`)   |
-| `documentation/`      | `envited-x:isDocumentation`    | MUST        | `envited-x:isPublic`    | Documentation files (e.g., `.pdf`, `.txt`)      |
-| `metadata/`           | `envited-x:isMetadata`         | MUST        | `envited-x:isPublic`    | Domain metadata (e.g., `hdmap_instance.json`)   |
-| `media/`              | `envited-x:isMedia`            | MUST        | `envited-x:isPublic`    | Visualizations, images, GeoJSON, 3D previews    |
-| `validation-reports/` | `envited-x:isValidationReport` | RECOMMENDED | `envited-x:isPublic`    | Quality checker reports (e.g., `.xqar`, `.txt`) |
-| _(root)_              | `envited-x:isLicense`          | MUST        | `envited-x:isPublic`    | LICENSE file at the asset root                  |
-| _(root)_              | `envited-x:isManifest`         | MUST        | `envited-x:isPublic`    | `manifest_reference.json` at the asset root     |
+| Folder                | `envited-x` Category           | Required    | `envited-x` Access Role | Description                                            |
+| --------------------- | ------------------------------ | ----------- | ----------------------- | ------------------------------------------------------ |
+| `simulation-data/`    | `envited-x:isSimulationData`   | MUST        | `envited-x:isOwner`     | Core simulation data (for example, `.xodr`, `.xosc`)   |
+| `documentation/`      | `envited-x:isDocumentation`    | MUST        | `envited-x:isPublic`    | Documentation files (for example, `.pdf`, `.txt`)      |
+| `metadata/`           | `envited-x:isMetadata`         | MUST        | `envited-x:isPublic`    | Domain metadata (for example, `hdmap_instance.json`)   |
+| `media/`              | `envited-x:isMedia`            | MUST        | `envited-x:isPublic`    | Visualizations, images, GeoJSON, 3D previews           |
+| `validation-reports/` | `envited-x:isValidationReport` | RECOMMENDED | `envited-x:isPublic`    | Quality checker reports (for example, `.xqar`, `.txt`) |
+| _(root)_              | `envited-x:isLicense`          | MUST        | `envited-x:isPublic`    | LICENSE file at the asset root                         |
+| _(root)_              | `envited-x:isManifest`         | MUST        | `envited-x:isPublic`    | `manifest_reference.json` at the asset root            |
 
 > **Note:** The `envited-x` categories and access roles are formally defined in the [ENVITED-X Ontology][21] which extends the generic [Manifest Ontology][22].
 > The `envited-x:ExtendedLinkShape` constrains the allowed values for both `manifest:hasCategory` and `manifest:hasAccessRole`.
@@ -146,12 +146,12 @@ IPFS is a peer-to-peer content delivery network built around the innovation of c
 
 #### CID v1
 
-Artifacts uploaded to IPFS e.g. using services like [Pinata][9] MUST use the content identifier version [CID v1][11].  
+Artifacts uploaded to IPFS, for example using services like [Pinata][9] MUST use the content identifier version [CID v1][11].  
 In Pinata this is achievable through the API using the `pinataOptions` parameter, as outlined in the [documentation][10].
 
 #### File Naming
 
-Uploaded file names MUST exclude extensions (e.g., use `file` instead of `file.json`) to avoid issues such as double extensions during downloads (e.g., `file.json.json`).
+Uploaded file names MUST exclude extensions (for example, use `file` instead of `file.json`) to avoid issues such as double extensions during downloads (for example, `file.json.json`).
 
 ### 3. Privacy Layer
 
@@ -294,29 +294,30 @@ The compatibility with the current release of the [Gaia-X Policy Rules Complianc
 
 ## References
 
-- [Gaia-X 4 PLC-AAD Ontology Management Base][1]
-- [Gaia-X Ontology and SHACL shapes 2210][2]
+- [ASCS Ontology Management Base][1]
+- [Gaia-X Ontology and SHACL shapes][2]
 - [Gaia-X Trust Framework Schema][3]
 - [Gaia-X Trust Framework Shapes][4]
 - [GaiaX Compliant Claims Example][5]
-- [GaiaX 4 PLC-AAD Claim Compliance Provider][6]
+- [GaiaX Claim Compliance Provider][6]
 - [ASCS HD-Map Asset Example][7]
 - [IPFS][8]
-- [Pinata Documentation][10]
+- [Pinata][9]
+- [Pinata API Documentation][10]
+- [CID v1 Content Addressing][11]
 - [ENVITED-X Data Space Portal][12]
 - [EIP-712][13]
+- [SPDX License List][15]
 - [RFC 2119: Key Words for Use in RFCs to Indicate Requirement Levels][16]
 - [Gaia-X Policy Rules Compliance Document (Release 24.11)][17]
 - [Marketplace Contract Reference Implementation][18]
-- [ENVITED-X Simulation Asset Tools][20]
-- [ENVITED-X Ontology][21]
-- [Manifest Ontology][22]
+- [TZIP-21 Ontology][19]
 - [ENVITED-X Simulation Asset Tools][20]
 - [ENVITED-X Ontology][21]
 - [Manifest Ontology][22]
 
 [1]: https://github.com/ASCS-eV/ontology-management-base/
-[2]: https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/gx
+[2]: https://github.com/ASCS-eV/ontology-management-base/tree/main/artifacts/gx
 [3]: https://registry.lab.gaia-x.eu/v1/api/trusted-schemas-registry/v2/schemas/gax-trust-framework
 [4]: https://registry.lab.gaia-x.eu/v1/api/trusted-shape-registry/v1/shapes/jsonld/trustframework#
 [5]: https://github.com/GAIA-X4PLC-AAD/gaia-x-compliant-claims-example
@@ -324,16 +325,16 @@ The compatibility with the current release of the [Gaia-X Policy Rules Complianc
 [7]: https://github.com/ASCS-eV/hd-map-asset-example/releases/tag/v0.2.3
 [8]: https://ipfs.tech/
 [9]: https://pinata.cloud/
-[10]: https://docs.pinata.cloud/web3/pinning/pinata-metadata#pinataoptions
+[10]: https://docs.pinata.cloud/api-reference/endpoint/ipfs/pin-file-to-ipfs
 [11]: https://docs.ipfs.tech/concepts/content-addressing/#version-1-v1
 [12]: https://envited-x.net/
 [13]: https://eips.ethereum.org/EIPS/eip-712
 [14]: https://json-schema.org/understanding-json-schema/reference/string#dates-and-times
-[15]: https://softwareengineering.stackexchange.com/a/450839/443441
+[15]: https://spdx.org/licenses/
 [16]: https://datatracker.ietf.org/doc/html/rfc2119
 [17]: https://docs.gaia-x.eu/policy-rules-committee/compliance-document/24.11/
 [18]: https://github.com/ASCS-eV/smart-contracts/tree/main/contracts/marketplace/
-[19]: https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/tzip21
+[19]: https://github.com/ASCS-eV/ontology-management-base/tree/main/artifacts/tzip21
 [20]: https://github.com/openMSL/sl-5-8-asset-tools
 [21]: https://github.com/ASCS-eV/ontology-management-base/tree/main/artifacts/envited-x
 [22]: https://github.com/ASCS-eV/ontology-management-base/tree/main/artifacts/manifest

--- a/EVES/EVES-004/eves-004.md
+++ b/EVES/EVES-004/eves-004.md
@@ -50,7 +50,7 @@ This specification distinguishes between two formal roles: **Editors** and **App
 
 #### 1.5 Standards Enforcers (Editors)
 
-- Verify that proposals align with overarching governance and standards (e.g., Gaia-X, W3C, Tezos TZIPs).
+- Verify that proposals align with overarching governance and standards (for example, Gaia-X, W3C, Tezos TZIPs).
 - Ensure interoperability within the ENVITED ecosystem.
 
 #### 1.6 Approvers
@@ -135,7 +135,7 @@ Approvers operate on top of the Editors’ responsibilities, taking an active ro
 
 1. **Application Process**:
    - Anyone interested in becoming an EVES Editor can open a discussion in the ENVITED GitHub organization.
-   - Tag the current editors group (e.g., `@eves-editors`) in the discussion for visibility.
+   - Tag the current editors group (for example, `@eves-editors`) in the discussion for visibility.
 
 2. **Eligibility**:
    - Applicants MUST demonstrate familiarity with the EVES process, template, and standards as defined in [EVES-001](../EVES-001/eves-001.md) and this document.
@@ -155,7 +155,7 @@ The following points clarify limits to the Editor and Approver roles:
 1. **Creation of New EVES**
    - Neither Editors nor Approvers drive the creation of new EVES; the community identifies needs, and authors propose solutions.
 2. **Technical Designs or Implementations**
-   - They do not craft or own the underlying technical designs (e.g., code libraries).
+   - They do not craft or own the underlying technical designs (for example, code libraries).
      The community or EVES authors lead the design, while Editors and Approvers review it for feasibility.
 3. **Promotion or Adoption**
    - They are not tasked with marketing or ensuring the adoption of specific EVES.

--- a/EVES/EVES-005/eves-005.md
+++ b/EVES/EVES-005/eves-005.md
@@ -68,7 +68,7 @@ The negotiation process follows the dataspace protocol state machine with the fo
   Access to the contracted asset is authorized only when the VC is valid and a corresponding registry entry is found and valid.
 
 - **TERMINATED:**  
-  If any error occurs (e.g., invalid signatures, mismatched payloads, or a timeout) or if either party cancels the negotiation, the process transitions to the terminated state.
+  If any error occurs (for example, invalid signatures, mismatched payloads, or a timeout) or if either party cancels the negotiation, the process transitions to the terminated state.
 
 ### 2. Detailed Process Flow Example
 
@@ -105,7 +105,7 @@ The negotiation process follows the dataspace protocol state machine with the fo
 
 - **Verifiable Credential Format:**  
   The contract VC conforms to the SD-JWT VC specification (see [SD-JWT-based Verifiable Credentials (SD-JWT VC)](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-00.html) and [OpenID for Verifiable Credential Issuance - draft 15](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)).
-  It is intended for storage in wallets (e.g., Altme) and can be presented to endpoints running the [ssi-to-oidc-bridge](https://github.com/GAIA-X4PLC-AAD/ssi-to-oidc-bridge).
+  It is intended for storage in wallets (for example, Altme) and can be presented to endpoints running the [ssi-to-oidc-bridge](https://github.com/GAIA-X4PLC-AAD/ssi-to-oidc-bridge).
 
 - **Decentralized Registry and Scaling:**  
   Following the method outlined in [EVES-006](../EVES-006/eves-006.md) and inspired by [this paper](https://arxiv.org/pdf/2501.17089), a blockchain-based registry on Etherlink is used to store the hash and UUID of finalized VCs.
@@ -113,7 +113,7 @@ The negotiation process follows the dataspace protocol state machine with the fo
 
 - **Automation and Encrypted Inbox:**  
   An encrypted inbox system — optionally secured with DID keys - is used to exchange contract-related VCs.
-  The design minimizes manual interaction by automating transitions (e.g., from OFFERED to ACCEPTED under preset criteria) while still allowing explicit user confirmation when needed.
+  The design minimizes manual interaction by automating transitions (for example, from OFFERED to ACCEPTED under preset criteria) while still allowing explicit user confirmation when needed.
 
 - **State Machine Integration:**  
   The process adheres to the dataspace protocol state machine with the following states:  
@@ -205,14 +205,14 @@ Initial implementation steps include:
 
 2. **VC Generation and Signing:**  
    Implement services to generate SD-JWT VCs for contract offers and acceptances.
-   Both provider and consumer systems must support signing operations and storage (e.g., in wallets like Altme).
+   Both provider and consumer systems must support signing operations and storage (for example, in wallets like Altme).
 
 3. **Blockchain Registry Integration:**  
    Integrate with the decentralized registry on Etherlink to store the hash and UUID of finalized contract VCs.
    The provider must record a registry entry to transition the state from AGREED to FINALIZED.
 
 4. **Automated State Transitions:**  
-   Where possible, automate state transitions (e.g., from OFFERED to ACCEPTED or AGREED) while allowing manual intervention if necessary.
+   Where possible, automate state transitions (for example, from OFFERED to ACCEPTED or AGREED) while allowing manual intervention if necessary.
 
 5. **Operator Fee Management:**  
    The ENVITED-X Data Space operator reviews registry entries to verify successful contracts.

--- a/EVES/EVES-006/eves-006.md
+++ b/EVES/EVES-006/eves-006.md
@@ -99,8 +99,8 @@ This specification extends ENVITED-X functionality without modifying existing co
 ## References
 
 1. [Etherlink Documentation](https://docs.etherlink.com/)
-2. [Tezos FA2.1 Standard](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-21/tzip-21.md)
-3. [Optimistic Rollups in Tezos](https://research.tezos.com/optimistic-rollups)
+2. [Tezos FA2.1 Standard](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-21/tzip-21.md)
+3. [Smart Optimistic Rollups in Tezos](https://docs.tezos.com/architecture/smart-rollups)
 4. [Bridging FA Tokens on Etherlink](https://docs.etherlink.com/bridging/bridging-fa)
 5. [ERC-721 Standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-721/)
 6. [Rio Protocol Announcement](https://research-development.nomadic-labs.com/rio-announcement.html)

--- a/EVES/EVES-007/eves-007.md
+++ b/EVES/EVES-007/eves-007.md
@@ -53,7 +53,7 @@ urn:blockchain:{chain_namespace}:{chain_id}:contract:{contract_address}
 
 > **_NOTE:_**
 >
-> - The **namespace** follows **CAIP-2** (e.g., `tezos`, `eip155` for Ethereum).
+> - The **namespace** follows **CAIP-2** (for example, `tezos`, `eip155` for Ethereum).
 > - The **chain_id** follows **CAIP-10**, ensuring unique chain differentiation.
 > - **Smart contracts (KT1, 0x) are explicitly named** under the `contract` identifier.
 
@@ -160,7 +160,7 @@ It is fully backward-compatible with Tezos, Ethereum, and Etherlink **without re
 
 1. [CAIP-2: Blockchain Namespace Specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md)
 2. [CAIP-10: Blockchain Account Specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md)
-3. [Tezos TZIP-21](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-21/tzip-21.md)
+3. [Tezos TZIP-21](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-21/tzip-21.md)
 4. [Ethereum ERC-721 Standard](https://eips.ethereum.org/EIPS/eip-721)
 5. [Etherlink Documentation](https://docs.etherlink.com/)
 6. [Etherlink Network Information](https://docs.etherlink.com/get-started/network-information/)

--- a/EVES/EVES-008/eves-008.md
+++ b/EVES/EVES-008/eves-008.md
@@ -104,13 +104,13 @@ did:ethr:<chainIdHex>:<ethereum-address>
 
 Entity types and their DID patterns:
 
-| Entity                 | Example DID                      |
-| ---------------------- | -------------------------------- |
-| Participant (ASCS)     | `did:ethr:0x14a34:0x5091...bb03` |
-| Participant (e.g. BMW) | `did:ethr:0x14a34:0x9d27...1048` |
-| Natural person         | `did:ethr:0x14a34:0xb2F7...b39a` |
-| Infrastructure service | `did:ethr:0x14a34:0x4612...46d1` |
-| Program definition     | `did:ethr:0x14a34:0x28b9...422D` |
+| Entity                         | Example DID                      |
+| ------------------------------ | -------------------------------- |
+| Participant (ASCS)             | `did:ethr:0x14a34:0x5091...bb03` |
+| Participant (for example, BMW) | `did:ethr:0x14a34:0x9d27...1048` |
+| Natural person                 | `did:ethr:0x14a34:0xb2F7...b39a` |
+| Infrastructure service         | `did:ethr:0x14a34:0x4612...46d1` |
+| Program definition             | `did:ethr:0x14a34:0x28b9...422D` |
 
 **Key management**: Signing DID documents MUST expose P-256 keys as `JsonWebKey` verification methods.
 The primary signing key is published as `#controller`; optional secondary keys appear as `#delegate-N`.
@@ -151,7 +151,7 @@ Example credential `@context`:
 }
 ```
 
-The SimpulseID context uses `@vocab: simpulseid:` which resolves bare `@id` values to the `simpulseid:` namespace. W3C terms (e.g., `VerifiableCredential`, `issuer`, `validFrom`) remain bare; all domain types MUST use prefixed CURIEs (e.g., `simpulseid:ParticipantCredential`, `harbour:CRSetEntry`).
+The SimpulseID context uses `@vocab: simpulseid:` which resolves bare `@id` values to the `simpulseid:` namespace. W3C terms (for example, `VerifiableCredential`, `issuer`, `validFrom`) remain bare; all domain types MUST use prefixed CURIEs (for example, `simpulseid:ParticipantCredential`, `harbour:CRSetEntry`).
 
 #### 3.3 Schema and Ontology
 
@@ -202,8 +202,8 @@ Membership credentials MUST use `urn:uuid:` identifiers to avoid RDF graph merge
 
 **`member` vs `memberOf` convention**:
 
-- `schema:member` is used **on the membership object**, pointing **to the member** (e.g., `AscsBaseMembership.member = <BMW DID>`).
-- `schema:memberOf` is used **on the person**, pointing **to the organization** they belong to (e.g., `Administrator.memberOf = [<BMW DID>]`).
+- `schema:member` is used **on the membership object**, pointing **to the member** (for example, `AscsBaseMembership.member = <BMW DID>`).
+- `schema:memberOf` is used **on the person**, pointing **to the organization** they belong to (for example, `Administrator.memberOf = [<BMW DID>]`).
 
 Implementers MUST NOT interchange these properties.
 

--- a/EVES/README.md
+++ b/EVES/README.md
@@ -48,7 +48,7 @@ _-> This document, providing an overview of the repository._
 ## How to Use This Repository
 
 1. **Explore Specifications**:
-   - Navigate to `SUMMARY.md` to view an overview of the specifications specifications.
+   - Navigate to `SUMMARY.md` to view an overview of the specifications.
    - Check the EVES `status` for work in progress and contribute to discussions.
 
 2. **Propose a New EVES**:

--- a/EVES/resources/eves-template.md
+++ b/EVES/resources/eves-template.md
@@ -24,7 +24,7 @@ _Provide the detailed technical or procedural content of the EVES. This section 
 
 ### 1. Lifecycle (if applicable)
 
-_Define the lifecycle or steps related to the EVES, e.g., stages for a process or implementation details for standards._
+_Define the lifecycle or steps related to the EVES, for example, stages for a process or implementation details for standards._
 
 ### 2. Key Definitions or Components (if applicable)
 
@@ -48,7 +48,7 @@ _Provide guidelines or requirements for how this EVES will be implemented, if ap
 
 ## Template Instructions
 
-- Replace `00X` with the EVES number (e.g., `001`, `002`).
+- Replace `00X` with the EVES number (for example, `001`, `002`).
 - Replace placeholder text (in square brackets `[]`) with actual content.
 - Delete this section ("Template Instructions") after completing the document.
 - Use consistent formatting to align with repository standards.

--- a/EVES/resources/style-guide.md
+++ b/EVES/resources/style-guide.md
@@ -32,7 +32,7 @@ All EVES must adhere to the following structure, as defined in EVES-001:
    status: [Draft/Final/Other]
    type: [Process/Standards/Informational]
    created: YYYY-MM-DD
-   requires: [List of EVES this depends on, e.g., "EVES-001"]
+   requires: [List of EVES this depends on, for example, "EVES-001"]
    replaces: None
    ---
    ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The goal of the EVES project is to specify and provide high-quality documentation for developing, distributing and using standard-compliant co-simulation artifacts and data.
 It is an initiative of the Automotive Solution Center for Simulation e.V. (ASCS) targeting the ecosystem around the [ENVITED-X Data Space](https://staging.envited-x.net/).
 
-The specifications itself are written as independent documents based on so-called "improvement protocols" typically used in de-centralized standardization efforts, e.g. in blockchain domains. These individual specification documents stand for themselves but can inherit from one another by reference.
+The specifications itself are written as independent documents based on so-called "improvement protocols" typically used in de-centralized standardization efforts, for example in blockchain domains. These individual specification documents stand for themselves but can inherit from one another by reference.
 
 All EVES documents are written in markdown format, sequentially numbered and stored in the [EVES folder](./EVES/).
 The process on how to write, submit or change specifications in defined in [EVES-001](./EVES/EVES-001/eves-001.md).


### PR DESCRIPTION
## Summary

- Update CI action versions (lychee-action v2.8.0, markdownlint-cli2-action v23.0.0)
- Replace mirrors-prettier with local `npx prettier --check` hook to match CI version and avoid unstaged files
- Add Vale to pre-commit hooks so prose lint failures are caught locally before push
- Disable Vale rules that conflict with technical specification conventions
- Replace all `e.g.` / `i.e.` with `for example` / `that is` across all EVES specs (Google.Latin rule)
- Fix broken external links (Pinata docs, ontology repos, GitLab TZIP namespace, Tezos research)
- Add `.lycheeignore` for forward references, placeholder URLs, and flaky sites
- Add `CLAUDE.md` with project setup and quality check instructions

## Test plan

- [x] `make lint` passes
- [x] `make format-check` passes
- [x] All pre-commit hooks pass (including Vale)
- [x] No remaining `e.g.` or `i.e.` in any EVES spec